### PR TITLE
Entity endpoint

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -216,6 +216,7 @@ const READING_PAGE_REWRITES = [
   ['/curated-collection', `${HOSTS.READING}/curated-collection`],
   ['/curated-collection/:path*', `${HOSTS.READING}/curated-collection/:path*`],
   ['/reading-room', HOSTS.READING],
+  ['/entity/:type/:slug', `${HOSTS.READING}/translation/entity/:type/:slug`],
 ];
 
 /** @type {[string, string][]} */


### PR DESCRIPTION
### Summary

Adds a rewrite mapping `/entity/:type/:slug` to the reading room's `/translation/entity/:type/slug`. Internal links expect a root `/entity` endpoint.